### PR TITLE
feat: HEX/RGB/HSL 表示行を ColorInputField に追加

### DIFF
--- a/src/__tests__/colorReadouts.test.ts
+++ b/src/__tests__/colorReadouts.test.ts
@@ -1,0 +1,53 @@
+// HEX → RGB / HSL の表示文字列フォーマット仕様の回帰防止
+// （ColorInputField の formatColorReadouts と同等のロジックを再生成）
+
+import chroma from 'chroma-js';
+
+function format(hex: string) {
+  const c = chroma(hex);
+  const [r, g, b] = c.rgb();
+  const [h, s, l] = c.hsl();
+  const hh = Number.isNaN(h) ? 0 : Math.round(h);
+  const ss = Math.round((Number.isNaN(s) ? 0 : s) * 100);
+  const ll = Math.round((Number.isNaN(l) ? 0 : l) * 100);
+  return {
+    rgb: `rgb(${r}, ${g}, ${b})`,
+    hsl: `hsl(${hh}, ${ss}%, ${ll}%)`,
+  };
+}
+
+describe('color readouts (HEX → RGB / HSL)', () => {
+  it('純粋な赤の rgb/hsl', () => {
+    expect(format('#ff0000')).toEqual({
+      rgb: 'rgb(255, 0, 0)',
+      hsl: 'hsl(0, 100%, 50%)',
+    });
+  });
+
+  it('純粋な青の rgb/hsl', () => {
+    expect(format('#0000ff')).toEqual({
+      rgb: 'rgb(0, 0, 255)',
+      hsl: 'hsl(240, 100%, 50%)',
+    });
+  });
+
+  it('白 (彩度 0) は hue が NaN にならない（0 にフォールバック）', () => {
+    expect(format('#ffffff')).toEqual({
+      rgb: 'rgb(255, 255, 255)',
+      hsl: 'hsl(0, 0%, 100%)',
+    });
+  });
+
+  it('黒も同様にフォールバックする', () => {
+    expect(format('#000000')).toEqual({
+      rgb: 'rgb(0, 0, 0)',
+      hsl: 'hsl(0, 0%, 0%)',
+    });
+  });
+
+  it('MUI primary blue の rgb/hsl', () => {
+    const r = format('#1976d2');
+    expect(r.rgb).toBe('rgb(25, 118, 210)');
+    expect(r.hsl).toMatch(/^hsl\(\d+, \d+%, \d+%\)$/);
+  });
+});

--- a/src/components/ColorInputField.tsx
+++ b/src/components/ColorInputField.tsx
@@ -1,19 +1,51 @@
-import { Box } from '@mui/material';
-import React, { useEffect, useState, memo } from 'react';
+import { Box, Tooltip, Typography } from '@mui/material';
+import React, { useEffect, useState, memo, useMemo } from 'react';
 
 import { SketchPicker } from 'react-color';
+import chroma from 'chroma-js';
 
 type ColorInputFieldProps = {
   color: string;
   onChange: (newColor: string) => void;
 };
 
+// chroma が壊れた hex を投げないようガードしつつ、HEX / RGB / HSL を 1 行ずつ表示
+function formatColorReadouts(hex: string): { rgb: string; hsl: string } | null {
+  try {
+    const c = chroma(hex);
+    const [r, g, b] = c.rgb();
+    const [h, s, l] = c.hsl();
+    const hh = Number.isNaN(h) ? 0 : Math.round(h);
+    const ss = Math.round((Number.isNaN(s) ? 0 : s) * 100);
+    const ll = Math.round((Number.isNaN(l) ? 0 : l) * 100);
+    return {
+      rgb: `rgb(${r}, ${g}, ${b})`,
+      hsl: `hsl(${hh}, ${ss}%, ${ll}%)`,
+    };
+  } catch {
+    return null;
+  }
+}
+
 const ColorInputField = memo(({ color, onChange }: ColorInputFieldProps) => {
   const [isMounted, setIsMounted] = useState(false);
+  const [copied, setCopied] = useState<'hex' | 'rgb' | 'hsl' | null>(null);
 
   useEffect(() => {
     setIsMounted(true);
   }, []);
+
+  const readouts = useMemo(() => formatColorReadouts(color), [color]);
+
+  const handleCopy = async (kind: 'hex' | 'rgb' | 'hsl', value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(kind);
+      window.setTimeout(() => setCopied(prev => (prev === kind ? null : prev)), 1200);
+    } catch {
+      /* clipboard 利用不可環境ではサイレントに失敗 */
+    }
+  };
 
   return (
     <Box
@@ -55,6 +87,68 @@ const ColorInputField = memo(({ color, onChange }: ColorInputFieldProps) => {
           }
           width='100%'
         />
+      )}
+
+      {readouts && (
+        <Box sx={{ mt: 0.75, display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+          {(
+            [
+              { kind: 'hex' as const, label: 'HEX', value: color.toUpperCase() },
+              { kind: 'rgb' as const, label: 'RGB', value: readouts.rgb },
+              { kind: 'hsl' as const, label: 'HSL', value: readouts.hsl },
+            ]
+          ).map(row => (
+            <Tooltip key={row.kind} arrow placement='right' title='クリックでコピー'>
+              <Box
+                onClick={() => handleCopy(row.kind, row.value)}
+                role='button'
+                aria-label={`${row.label} をコピー`}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 0.75,
+                  px: 0.75,
+                  py: 0.25,
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  bgcolor: copied === row.kind ? 'rgba(46,125,50,0.12)' : 'transparent',
+                  '&:hover': { bgcolor: 'rgba(0,0,0,0.04)' },
+                  transition: 'background-color 0.15s ease',
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontSize: '0.6rem',
+                    fontWeight: 700,
+                    letterSpacing: 0.5,
+                    color: 'rgba(0,0,0,0.5)',
+                    minWidth: 28,
+                  }}
+                >
+                  {row.label}
+                </Typography>
+                <Typography
+                  sx={{
+                    fontSize: '0.7rem',
+                    fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+                    color: '#1a1a2e',
+                    flex: 1,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {row.value}
+                </Typography>
+                {copied === row.kind && (
+                  <Typography sx={{ fontSize: '0.6rem', color: '#2e7d32', fontWeight: 700 }}>
+                    ✓ Copied
+                  </Typography>
+                )}
+              </Box>
+            </Tooltip>
+          ))}
+        </Box>
       )}
     </Box>
   );


### PR DESCRIPTION
## Summary
- Closes #7 — SketchPicker 直下に HEX / RGB / HSL の表示行を 3 行追加。各行クリックで clipboard にコピー
- chroma-js による変換。白/黒のように彩度 0 のケースで hue が NaN になるのを 0 に正規化

## Test plan
- [x] `tsc --noEmit` 緑
- [x] 新規ユニットテスト 5 件（純色 / モノクロ / MUI primary blue）緑
- [x] 既存テスト全緑

## Screenshot
SketchPicker の下にラベル付きの 3 行（HEX / RGB / HSL）が monospace フォントで表示される。クリックで `✓ Copied` バッジが 1.2s 表示される。