### PR TITLE
chore: Firebase を opt-in 機能に変更

### DIFF
--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -1,5 +1,12 @@
 # Firebase Setup Guide - Palette Pally
 
+> **Firebase は opt-in 機能です。** env 未設定のままでもアプリ本体（ColorPicker / Palette 生成 / Export / Import Hub）は動作します。Firebase を設定しない場合の挙動:
+>
+> - 本番 (`NODE_ENV=production`): `/api/figma/*` ルートのみ **503 Service Unavailable** を返す。他の UI / API は通常動作
+> - 開発 (`yarn dev`): `/api/figma/*` も fail-open で動く（警告ログは出る）
+>
+> 以下の手順は「将来的に Firebase で認証 + パレット保存 + Figma API 中継を有効化する」ときの導入ガイドです。
+
 ## 1. Firebase Project Creation
 
 1. Open [Firebase Console](https://console.firebase.google.com/)

--- a/src/__tests__/firebase-admin.test.ts
+++ b/src/__tests__/firebase-admin.test.ts
@@ -6,23 +6,41 @@
 
 import type { NextApiRequest } from 'next';
 
-describe('verifyAuth (dev escape hatch)', () => {
-  beforeEach(() => {
-    jest.resetModules();
+describe('verifyAuth', () => {
+  const clearEnv = () => {
     delete process.env.FIREBASE_ADMIN_CLIENT_EMAIL;
     delete process.env.FIREBASE_ADMIN_PRIVATE_KEY;
     delete process.env.FIREBASE_ADMIN_PROJECT_ID;
-    // ts-jest 5+ では NODE_ENV が readonly なので Object.defineProperty で書き込む
-    Object.defineProperty(process.env, 'NODE_ENV', { value: 'test', configurable: true });
+  };
+  const setNodeEnv = (v: string) =>
+    Object.defineProperty(process.env, 'NODE_ENV', { value: v, configurable: true });
+
+  beforeEach(() => {
+    jest.resetModules();
+    clearEnv();
   });
 
   it('admin env 未設定 + 非 production では fail-open し dev-anonymous を返す', async () => {
+    setNodeEnv('test');
     const { verifyAuth } = await import('@/lib/firebase/admin');
     const req = { headers: {} } as NextApiRequest;
     const result = await verifyAuth(req);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.uid).toBe('dev-anonymous');
+    }
+  });
+
+  it('admin env 未設定 + production では 503 (opt-in 機能として無効)', async () => {
+    setNodeEnv('production');
+    const { verifyAuth, isAdminConfigured } = await import('@/lib/firebase/admin');
+    expect(isAdminConfigured).toBe(false);
+    const req = { headers: {} } as NextApiRequest;
+    const result = await verifyAuth(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(503);
+      expect(result.error).toMatch(/not enabled/i);
     }
   });
 });

--- a/src/lib/firebase/admin.ts
+++ b/src/lib/firebase/admin.ts
@@ -1,9 +1,15 @@
 // Firebase Admin SDK – server-only。API ルートで ID トークンを検証する。
-// env 未設定時の挙動:
-//   - dev (NODE_ENV !== 'production'): 認証スキップ + 警告ログ
-//   - prod: 起動時に throw して fail-closed
+// Firebase は opt-in 機能。env 未設定でもアプリ全体は動き、Firebase 依存 API
+// （現状 /api/figma/*）だけが無効化される。
 //
-// 必要 env:
+// 挙動マトリクス:
+//   | NODE_ENV   | env 設定 | 挙動                                              |
+//   | prod       | 有      | Bearer トークン検証                               |
+//   | prod       | 無      | 503 Service Unavailable（機能自体が opt-in のため） |
+//   | 非 prod    | 有      | Bearer トークン検証                               |
+//   | 非 prod    | 無      | 認証スキップ + 警告ログ（dev escape hatch）       |
+//
+// 必要 env (すべて有効化する場合):
 //   FIREBASE_ADMIN_CLIENT_EMAIL
 //   FIREBASE_ADMIN_PRIVATE_KEY  （JSON 由来の \n を含むため改行のエスケープに注意）
 //   FIREBASE_ADMIN_PROJECT_ID   （省略時は NEXT_PUBLIC_FIREBASE_PROJECT_ID にフォールバック）
@@ -20,16 +26,10 @@ const privateKey = rawPrivateKey?.replace(/\\n/g, '\n');
 const projectId =
   process.env.FIREBASE_ADMIN_PROJECT_ID ?? process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
 
-const isConfigured = Boolean(clientEmail && privateKey && projectId);
-
-if (!isConfigured && isProd) {
-  throw new Error(
-    'firebase-admin: required env not set (FIREBASE_ADMIN_CLIENT_EMAIL / FIREBASE_ADMIN_PRIVATE_KEY / FIREBASE_ADMIN_PROJECT_ID)'
-  );
-}
+export const isAdminConfigured = Boolean(clientEmail && privateKey && projectId);
 
 let app: App | null = null;
-if (isConfigured) {
+if (isAdminConfigured) {
   app = getApps()[0] ?? initializeApp({
     credential: cert({ projectId, clientEmail, privateKey }),
   });
@@ -40,8 +40,15 @@ export type AuthResult =
   | { ok: false; status: number; error: string };
 
 export async function verifyAuth(req: NextApiRequest): Promise<AuthResult> {
-  if (!isConfigured) {
-    // dev escape hatch — fail-open のみ
+  if (!isAdminConfigured) {
+    if (isProd) {
+      return {
+        ok: false,
+        status: 503,
+        error:
+          'Firebase-backed API is not enabled on this deployment. Set FIREBASE_ADMIN_CLIENT_EMAIL / FIREBASE_ADMIN_PRIVATE_KEY / FIREBASE_ADMIN_PROJECT_ID to activate.',
+      };
+    }
     // eslint-disable-next-line no-console
     console.warn('[verifyAuth] firebase-admin not configured — bypassing in non-production');
     return { ok: true, uid: 'dev-anonymous', token: {} as DecodedIdToken };


### PR DESCRIPTION
## Summary
Firebase の設定前でも本番デプロイが成立するよう、`verifyAuth` の挙動を opt-in 方式に変更。

## 挙動マトリクス

| NODE_ENV | admin env | 挙動 |
|---|---|---|
| prod | 有 | Bearer トークン検証（変更なし） |
| prod | **無** | **503 Service Unavailable**（旧: 起動 throw） |
| dev | 有 | Bearer トークン検証（変更なし） |
| dev | 無 | 認証スキップ + 警告（変更なし） |

`/api/figma/*` だけが無効化され、ColorPicker / Palette 生成 / Export / Import Hub など本体機能は継続動作する。

## Test plan
- [x] `tsc --noEmit` 緑
- [x] 既存の dev fail-open + 新規の prod 503 のユニットテスト 2 件緑
- [x] 既存全テスト緑

## Motivation
Firebase Project がまだ作成されていない状態で本番デプロイを試みても起動失敗しないようにする。将来 Firebase を有効化するときは `FIREBASE_ADMIN_*` env を追加するだけで認証が有効になる（コード変更不要）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * Firebase はオプション機能であることを明記しました。アプリケーションのコア機能は Firebase 環境変数なしでも動作します。

* **改善**
  * Firebase が設定されていない場合の本番環境でのエラーハンドリングが改善されました。適切なエラーレスポンスを返すようになりました。開発環境ではログ警告とともにフェイルオープン動作に対応。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->