### PR TITLE
fix: Example preview の dark テキスト不可読を WCAG セーフネットで修正

### DIFF
--- a/src/__tests__/buildMuiTheme.test.ts
+++ b/src/__tests__/buildMuiTheme.test.ts
@@ -1,0 +1,64 @@
+import { buildMuiTheme } from '@/lib/theme/buildMuiTheme';
+import { PaletteData } from '@/lib/types/palette';
+import chroma from 'chroma-js';
+
+const baseData: PaletteData = {
+  numColors: 1,
+  colors: ['#1976d2'],
+  names: ['primary'],
+  palette: [
+    {
+      primary: {
+        light: { main: '#1976d2', dark: '#115293', light: '#42a5f5', lighter: '#e3f2fd', contrastText: '#ffffff' },
+        dark: { main: '#90caf9', dark: '#64b5f6', light: '#bbdefb', lighter: '#1e3a5f', contrastText: '#000000' },
+      },
+    },
+  ],
+  themeTokens: null,
+};
+
+describe('buildMuiTheme — dark text contrast safety net', () => {
+  it('破損した暗すぎる text.secondary は fallback に置換される', () => {
+    const data: PaletteData = {
+      ...baseData,
+      themeTokens: {
+        grey: { light: {}, dark: {} },
+        utility: {
+          light: { text: { primary: '#000', secondary: '#333', disabled: '#777' } },
+          // dark 側に明らかに読めない値（背景 bg.default に対して contrast < 4.5）
+          dark: { text: { primary: '#1a1c1e', secondary: '#1a1c1e', disabled: '#222' } },
+        },
+      },
+    };
+    const theme = buildMuiTheme(data, 'dark');
+    const bg = theme.palette.background.default;
+    expect(chroma.contrast(theme.palette.text.primary, bg)).toBeGreaterThanOrEqual(4.5);
+    expect(chroma.contrast(theme.palette.text.secondary, bg)).toBeGreaterThanOrEqual(4.5);
+    expect(chroma.contrast(theme.palette.text.disabled, bg)).toBeGreaterThanOrEqual(3);
+  });
+
+  it('適正な text トークンはそのまま使われる', () => {
+    const data: PaletteData = {
+      ...baseData,
+      themeTokens: {
+        grey: { light: {}, dark: {} },
+        utility: {
+          light: { text: {} },
+          dark: { text: { primary: '#e4e4e7', secondary: '#a1a1aa', disabled: '#9ca3af' } },
+        },
+      },
+    };
+    const theme = buildMuiTheme(data, 'dark');
+    expect(theme.palette.text.primary).toBe('#e4e4e7');
+    expect(theme.palette.text.secondary).toBe('#a1a1aa');
+    expect(theme.palette.text.disabled).toBe('#9ca3af');
+  });
+
+  it('themeTokens が null でもフォールバック値が WCAG を満たす', () => {
+    const theme = buildMuiTheme(baseData, 'dark');
+    const bg = theme.palette.background.default;
+    expect(chroma.contrast(theme.palette.text.primary, bg)).toBeGreaterThanOrEqual(4.5);
+    expect(chroma.contrast(theme.palette.text.secondary, bg)).toBeGreaterThanOrEqual(4.5);
+    expect(chroma.contrast(theme.palette.text.disabled, bg)).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/lib/theme/buildMuiTheme.ts
+++ b/src/lib/theme/buildMuiTheme.ts
@@ -1,6 +1,19 @@
 import { createTheme, Theme, ThemeOptions } from '@mui/material/styles';
+import chroma from 'chroma-js';
 import { PaletteData } from '@/lib/types/palette';
 import { MuiColorVariant } from '@/components/colorUtils';
+
+// 指定色が背景に対して minRatio を満たさなければ fallback を返す。
+// localStorage に壊れた / 暗すぎる utility.text.* が保存されているケースで
+// dark preview 全体が読めなくなるのを防ぐセーフネット。
+function ensureReadable(color: string, bg: string, minRatio: number, fallback: string): string {
+  try {
+    if (chroma.contrast(color, bg) >= minRatio) return color;
+  } catch {
+    // invalid color -> fallback
+  }
+  return fallback;
+}
 
 // パレット内から指定名の MuiColorVariant を検索 (大文字小文字無視)
 function findByName(
@@ -96,11 +109,19 @@ export function buildMuiTheme(data: PaletteData, mode: 'light' | 'dark'): Theme 
         },
       }),
       grey: grey as Record<string, string>,
-      text: {
-        primary: utility.text?.primary ?? (mode === 'light' ? '#1a1a2e' : '#e4e4e7'),
-        secondary: utility.text?.secondary ?? (mode === 'light' ? '#4a5568' : '#a1a1aa'),
-        disabled: utility.text?.disabled ?? (mode === 'light' ? '#9e9e9e' : '#6b7280'),
-      },
+      text: (() => {
+        const bgDefault = utility.background?.default ?? (mode === 'light' ? '#f8fafc' : '#18181b');
+        const fbPrimary = mode === 'light' ? '#1a1a2e' : '#e4e4e7';
+        const fbSecondary = mode === 'light' ? '#4a5568' : '#a1a1aa';
+        const fbDisabled = mode === 'light' ? '#9e9e9e' : '#9ca3af';
+        return {
+          // 通常テキストは WCAG AA (4.5:1)、disabled は AA-Large (3:1) を最低保証。
+          // 満たさない値は上記 fallback に置換する（壊れた localStorage データへのセーフネット）
+          primary: ensureReadable(utility.text?.primary ?? fbPrimary, bgDefault, 4.5, fbPrimary),
+          secondary: ensureReadable(utility.text?.secondary ?? fbSecondary, bgDefault, 4.5, fbSecondary),
+          disabled: ensureReadable(utility.text?.disabled ?? fbDisabled, bgDefault, 3, fbDisabled),
+        };
+      })(),
       background: {
         default: utility.background?.default ?? (mode === 'light' ? '#f8fafc' : '#18181b'),
         paper: utility.background?.paper ?? (mode === 'light' ? '#ffffff' : '#27272a'),


### PR DESCRIPTION
## Problem
Example ページの dark モードで Body 2 / Caption が背景に同化して読めない。原因は `buildMuiTheme` が localStorage の `themeTokens.utility.dark.text.*` を無条件に採用しており、壊れた / 暗すぎる値が混ざっていても素通ししていたため。

## Fix
`ensureReadable(color, bg, minRatio, fallback)` ヘルパーを導入。`text.primary` / `secondary` に 4.5:1、`disabled` に 3:1 を最低保証。満たさない値は fallback に置換する。fallback の dark `disabled` も `#6b7280` → `#9ca3af` に引き上げて bg.default に対して 3:1 を確保。

## Test
- [x] 破損値が置換されることを検証する 3 ケースを `buildMuiTheme.test.ts` に追加
- [x] 全 22 suites / 258 tests 緑
- [ ] Example ページで dark preview を目視確認