### PR TITLE
feat: UtilityGroupCard を LIGHT/DARK 縦 stack 表示に

### DIFF
--- a/src/components/ThemeTokenCards.tsx
+++ b/src/components/ThemeTokenCards.tsx
@@ -740,7 +740,11 @@ export const UtilityGroupCard = memo<{
           {onUpdate && <EditButton onClick={() => setDialogOpen(true)} />}
         </Box>
       </Box>
-      <Box sx={{ display: 'flex', gap: 0.75, p: 1, bgcolor: '#fff' }}>
+      {/* UtilityGroupCard は LIGHT / DARK を縦 stack で表示し、各 swatch の
+          横幅を最大化して rgba() 等の長い値が省略されないようにする。
+          Grey (GreyScaleCard) は 50-900 の短い数字ラベル + 短い hex 値なので
+          従来の横並び 2 列のまま（別コンポーネントで影響なし）。 */}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75, p: 1, bgcolor: '#fff' }}>
         <TokenColumn mode='light' onCopy={handleCopy} copyData={lightEntries}>
           {entryKeys.map(k => (
             <TokenSwatch


### PR DESCRIPTION
## Problem
Theme Tokens の Text / Background / Surface / Action / Divider カードは LIGHT と DARK を横並び 2 列で表示しており、各セル幅が狭くて rgba() など長い値が省略されて読めなかった。

## Fix
`UtilityGroupCard` の inner layout を `flexDirection: 'column'` に変更し、LIGHT カラム → DARK カラムの縦 stack に。swatch の横幅がカード幅いっぱいになり、値の省略が解消される。

`GreyScaleCard` は 50-900 の短い数字ラベル + 短い hex 値で 2 列でも省略されないため、従来どおり（別コンポーネントで影響なし）。

## Test
- [x] 全 22 suites / 258 tests 緑
- [ ] 目視確認