### PR TITLE
feat: App-level dark mode (MUI theme integration) — closes #9

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,10 @@
 import type { AppProps } from 'next/app';
 import createCache from '@emotion/cache';
-import { theme } from '@/lib/theme';
 import Head from 'next/head';
 import '../src/styles/globals.css';
-import { ThemeProvider, CacheProvider } from '@emotion/react';
+import { CacheProvider } from '@emotion/react';
 import { AuthProvider } from '@/components/auth/AuthProvider';
+import { AppShell } from '@/components/common/AppShell';
 
 export default function App({ Component, pageProps }: AppProps) {
   const cache = createCache({ key: 'css', prepend: true, stylisPlugins: [] });
@@ -12,7 +12,7 @@ export default function App({ Component, pageProps }: AppProps) {
 
   return (
     <AuthProvider>
-      <ThemeProvider theme={theme}>
+      <AppShell>
         <CacheProvider value={cache}>
           <Head>
             <title>Pallett Pally - MUI カラーパレット生成</title>
@@ -21,7 +21,7 @@ export default function App({ Component, pageProps }: AppProps) {
           </Head>
           <Component {...pageProps} />
         </CacheProvider>
-      </ThemeProvider>
+      </AppShell>
     </AuthProvider>
   );
 }

--- a/src/__tests__/createAppTheme.test.ts
+++ b/src/__tests__/createAppTheme.test.ts
@@ -1,0 +1,45 @@
+import { createAppTheme, darkTheme, theme as lightTheme } from '@/lib/theme';
+import chroma from 'chroma-js';
+
+describe('createAppTheme', () => {
+  it("'light' は既存 theme を返す", () => {
+    expect(createAppTheme('light')).toBe(lightTheme);
+  });
+
+  it("'dark' は darkTheme を返す", () => {
+    expect(createAppTheme('dark')).toBe(darkTheme);
+  });
+
+  it('darkTheme の palette.mode は dark', () => {
+    expect(darkTheme.palette.mode).toBe('dark');
+  });
+
+  it('darkTheme の text.primary は背景に対して WCAG AA (4.5:1) を満たす', () => {
+    const ratio = chroma.contrast(
+      darkTheme.palette.text.primary,
+      darkTheme.palette.background.default,
+    );
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('darkTheme の text.secondary は背景に対して WCAG AA (4.5:1) を満たす', () => {
+    const ratio = chroma.contrast(
+      darkTheme.palette.text.secondary,
+      darkTheme.palette.background.default,
+    );
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('darkTheme の text.disabled は背景に対して AA-Large (3:1) を満たす', () => {
+    const ratio = chroma.contrast(
+      darkTheme.palette.text.disabled,
+      darkTheme.palette.background.default,
+    );
+    expect(ratio).toBeGreaterThanOrEqual(3);
+  });
+
+  it('darkTheme の typography.allVariants.color は dark primary と一致（親 theme の allVariants.color 汚染を遮断）', () => {
+    const allVariants = darkTheme.typography as unknown as { allVariants: { color: string } };
+    expect(allVariants.allVariants.color).toBe(darkTheme.palette.text.primary);
+  });
+});

--- a/src/__tests__/useColorScheme.test.tsx
+++ b/src/__tests__/useColorScheme.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { useColorScheme, ColorScheme } from '@/hooks/useColorScheme';
+
+// Test-only harness: hook を component 内で呼び出して内部状態を外に晒す
+function Harness({ onReady }: { onReady: (api: ReturnType<typeof useColorScheme>) => void }) {
+  const api = useColorScheme();
+  React.useEffect(() => { onReady(api); }, [api, onReady]);
+  return <div data-testid='resolved'>{api.resolved}</div>;
+}
+
+describe('useColorScheme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-color-scheme');
+    document.documentElement.style.colorScheme = '';
+  });
+
+  it('初回訪問は light で起動する（OS が dark でも勝手に system にしない）', () => {
+    const ref: { api?: ReturnType<typeof useColorScheme> } = {};
+    render(<Harness onReady={api => { ref.api = api; }} />);
+    expect(ref.api?.scheme).toBe('light');
+    expect(ref.api?.resolved).toBe('light');
+  });
+
+  it('localStorage に保存した scheme が復元される', () => {
+    localStorage.setItem('palettePallyColorScheme', 'dark');
+    const ref: { api?: ReturnType<typeof useColorScheme> } = {};
+    render(<Harness onReady={api => { ref.api = api; }} />);
+    expect(ref.api?.scheme).toBe('dark');
+    expect(ref.api?.resolved).toBe('dark');
+    expect(document.documentElement.dataset.colorScheme).toBe('dark');
+  });
+
+  it('setScheme で切替時に localStorage と data 属性が更新される', () => {
+    const ref: { api?: ReturnType<typeof useColorScheme> } = {};
+    render(<Harness onReady={api => { ref.api = api; }} />);
+    act(() => { ref.api?.setScheme('dark'); });
+    expect(localStorage.getItem('palettePallyColorScheme')).toBe('dark');
+    expect(document.documentElement.dataset.colorScheme).toBe('dark');
+  });
+
+  it('toggle は light→dark→system→light のサイクル', () => {
+    const ref: { api?: ReturnType<typeof useColorScheme> } = {};
+    render(<Harness onReady={api => { ref.api = api; }} />);
+    expect(ref.api?.scheme).toBe('light');
+    act(() => { ref.api?.toggle(); });
+    expect(ref.api?.scheme).toBe('dark');
+    act(() => { ref.api?.toggle(); });
+    expect(ref.api?.scheme).toBe('system');
+    act(() => { ref.api?.toggle(); });
+    expect(ref.api?.scheme).toBe('light');
+  });
+
+  it('不正な localStorage 値は light にフォールバック', () => {
+    localStorage.setItem('palettePallyColorScheme', 'invalid-value' as ColorScheme);
+    const ref: { api?: ReturnType<typeof useColorScheme> } = {};
+    render(<Harness onReady={api => { ref.api = api; }} />);
+    expect(ref.api?.scheme).toBe('light');
+  });
+});

--- a/src/components/ColorInputField.tsx
+++ b/src/components/ColorInputField.tsx
@@ -112,7 +112,7 @@ const ColorInputField = memo(({ color, onChange }: ColorInputFieldProps) => {
                   borderRadius: '4px',
                   cursor: 'pointer',
                   bgcolor: copied === row.kind ? 'rgba(46,125,50,0.12)' : 'transparent',
-                  '&:hover': { bgcolor: 'rgba(0,0,0,0.04)' },
+                  '&:hover': { bgcolor: 'action.hover' },
                   transition: 'background-color 0.15s ease',
                 }}
               >
@@ -121,7 +121,7 @@ const ColorInputField = memo(({ color, onChange }: ColorInputFieldProps) => {
                     fontSize: '0.6rem',
                     fontWeight: 700,
                     letterSpacing: 0.5,
-                    color: 'rgba(0,0,0,0.5)',
+                    color: 'text.secondary',
                     minWidth: 28,
                   }}
                 >
@@ -131,7 +131,7 @@ const ColorInputField = memo(({ color, onChange }: ColorInputFieldProps) => {
                   sx={{
                     fontSize: '0.7rem',
                     fontFamily: '"JetBrains Mono", "Fira Code", monospace',
-                    color: '#1a1a2e',
+                    color: 'text.primary',
                     flex: 1,
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -15,6 +15,8 @@ import { ConfirmDialog } from './common/ConfirmDialog';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { useHistory } from '@/hooks/useHistory';
 import { useAppTheme } from '@/hooks/useAppTheme';
+import { useAppColors, AppColors } from '@/hooks/useAppColors';
+import { ColorSchemeToggle } from './common/ColorSchemeToggle';
 import { HarmonyDialog } from './harmony/HarmonyDialog';
 import { CompareDialog } from './compare/CompareDialog';
 import { useAuthContext } from './auth/AuthProvider';
@@ -42,9 +44,9 @@ import * as firestoreService from '@/lib/firebase/firestore';
 const LogoMark = () => (
   <svg width='48' height='40' viewBox='0 0 48 40' fill='none'>
     {/* ハンドリフト本体 (L字フレーム) */}
-    <path d='M 2 3 L 6 3 L 6 30 L 46 30 L 46 33 L 2 33 Z' fill='#1a1a2e' />
+    <path d='M 2 3 L 6 3 L 6 30 L 46 30 L 46 33 L 2 33 Z' fill='currentColor' />
     {/* 車輪 */}
-    <circle cx='8' cy='36' r='2.5' fill='none' stroke='#1a1a2e' strokeWidth='1.5' />
+    <circle cx='8' cy='36' r='2.5' fill='none' stroke='currentColor' strokeWidth='1.5' />
     {/* カラー版ブロック (テトリス状配置) */}
     <rect x='9' y='5' width='18' height='6' rx='1' fill='#E57373' />
     <rect x='29' y='5' width='15' height='6' rx='1' fill='#4DB6AC' />
@@ -53,35 +55,40 @@ const LogoMark = () => (
     <rect x='9' y='21' width='12' height='6' rx='1' fill='#FFD54F' />
     <rect x='23' y='21' width='21' height='6' rx='1' fill='#B39DDB' />
     {/* パレット支柱 */}
-    <rect x='10' y='33' width='4' height='3' fill='#1a1a2e' />
-    <rect x='23' y='33' width='4' height='3' fill='#1a1a2e' />
-    <rect x='36' y='33' width='4' height='3' fill='#1a1a2e' />
+    <rect x='10' y='33' width='4' height='3' fill='currentColor' />
+    <rect x='23' y='33' width='4' height='3' fill='currentColor' />
+    <rect x='36' y='33' width='4' height='3' fill='currentColor' />
   </svg>
 );
 
-// ヘッダーボタンの共通スタイル
-const headerButtonSx = {
-  minWidth: 0,
-  px: 1.5,
-  py: 0.625,
-  borderRadius: '8px',
-  border: '1px solid rgba(0,0,0,0.12)',
-  bgcolor: '#f5f5f5',
-  color: '#1a1a2e',
-  fontSize: '0.72rem',
-  fontWeight: 600,
-  textTransform: 'none' as const,
-  letterSpacing: '0.01em',
-  transition: 'all 0.15s ease',
-  '&:hover': {
-    bgcolor: '#eaeaea',
-    borderColor: 'rgba(0,0,0,0.2)',
-  },
-};
+// ヘッダーボタン共通スタイル。app color scheme に追従するので関数化し、
+// ColorPicker 内で useMemo で安定化する。
+function makeHeaderButtonSx(c: AppColors) {
+  return {
+    minWidth: 0,
+    px: 1.5,
+    py: 0.625,
+    borderRadius: '8px',
+    border: `1px solid ${c.border}`,
+    bgcolor: c.chromeBg,
+    color: c.textPrimary,
+    fontSize: '0.72rem',
+    fontWeight: 600,
+    textTransform: 'none' as const,
+    letterSpacing: '0.01em',
+    transition: 'all 0.15s ease',
+    '&:hover': {
+      bgcolor: c.chromeBgHover,
+      borderColor: c.borderHover,
+    },
+  };
+}
 
 function ColorPicker() {
   const { user, firebaseReady } = useAuthContext();
   const { state: confirmState, confirm, handleConfirm, handleCancel } = useConfirmDialog();
+  const c = useAppColors();
+  const headerButtonSx = React.useMemo(() => makeHeaderButtonSx(c), [c]);
 
   // Cloud state
   const [loginOpen, setLoginOpen] = useState(false);
@@ -493,7 +500,17 @@ function ColorPicker() {
   };
 
   return (
-    <>
+    <Box
+      sx={{
+        // Generator chrome（ヘッダー/ツールバー/ページ背景）を color scheme に追従。
+        // user palette (PaletteCard 内の色) はこの wrapper の影響を受けず自分の
+        // 色で描画される。
+        bgcolor: c.pageBg,
+        color: c.textPrimary,
+        minHeight: '100vh',
+        transition: 'background-color 0.2s ease, color 0.2s ease',
+      }}
+    >
       {/* ===== Header ===== */}
       <Box
         component='header'
@@ -503,8 +520,7 @@ function ColorPicker() {
           justifyContent: 'space-between',
           mb: 4,
           pb: 2.5,
-          borderBottom: '1px solid',
-          borderColor: 'rgba(0,0,0,0.06)',
+          borderBottom: `1px solid ${c.divider}`,
         }}
       >
         {/* Logo + Title */}
@@ -517,7 +533,7 @@ function ColorPicker() {
                 fontSize: '1.35rem',
                 fontWeight: 700,
                 letterSpacing: '-0.02em',
-                color: '#1a1a2e',
+                color: c.textPrimary,
                 lineHeight: 1.2,
               }}
             >
@@ -526,7 +542,7 @@ function ColorPicker() {
             <Typography
               sx={{
                 fontSize: '0.65rem',
-                color: 'rgba(0,0,0,0.35)',
+                color: c.textSubtle,
                 fontWeight: 500,
                 letterSpacing: '0.04em',
                 lineHeight: 1,
@@ -546,11 +562,11 @@ function ColorPicker() {
               display: 'flex',
               alignItems: 'center',
               gap: 0.75,
-              bgcolor: '#f5f5f5',
+              bgcolor: c.chromeBg,
               borderRadius: '8px',
               px: 1.25,
               py: 0.5,
-              border: '1px solid rgba(0,0,0,0.1)',
+              border: `1px solid ${c.divider}`,
             }}
           >
             <Typography
@@ -559,7 +575,7 @@ function ColorPicker() {
               sx={{
                 fontSize: '0.7rem',
                 fontWeight: 600,
-                color: 'rgba(0,0,0,0.5)',
+                color: c.textMuted,
                 textTransform: 'uppercase',
                 letterSpacing: '0.05em',
                 whiteSpace: 'nowrap',
@@ -580,10 +596,10 @@ function ColorPicker() {
               sx={{
                 width: 52,
                 '& .MuiOutlinedInput-root': {
-                  bgcolor: '#fff',
+                  bgcolor: c.chromeBgActive,
                   borderRadius: '6px',
-                  '& fieldset': { borderColor: 'rgba(0,0,0,0.1)' },
-                  '&:hover fieldset': { borderColor: 'rgba(0,0,0,0.2)' },
+                  '& fieldset': { borderColor: c.divider },
+                  '&:hover fieldset': { borderColor: c.borderHover },
                 },
                 '& input': {
                   py: 0.5,
@@ -597,7 +613,7 @@ function ColorPicker() {
           </Box>
 
           {/* Divider */}
-          <Box sx={{ width: '1px', height: 24, bgcolor: 'rgba(0,0,0,0.1)' }} />
+          <Box sx={{ width: '1px', height: 24, bgcolor: c.divider }} />
 
           {/* Undo / Redo */}
           <Tooltip title='Undo (⌘Z)' arrow>
@@ -608,8 +624,8 @@ function ColorPicker() {
                 size='small'
                 sx={{
                   width: 34, height: 34, borderRadius: '8px',
-                  border: '1px solid rgba(0,0,0,0.12)', bgcolor: '#f5f5f5', color: '#1a1a2e',
-                  '&:hover': { bgcolor: '#eaeaea', borderColor: 'rgba(0,0,0,0.2)' },
+                  border: `1px solid ${c.border}`, bgcolor: c.chromeBg, color: c.textPrimary,
+                  '&:hover': { bgcolor: c.chromeBgHover, borderColor: c.borderHover },
                   '&:disabled': { opacity: 0.4 },
                 }}
               >
@@ -628,8 +644,8 @@ function ColorPicker() {
                 size='small'
                 sx={{
                   width: 34, height: 34, borderRadius: '8px',
-                  border: '1px solid rgba(0,0,0,0.12)', bgcolor: '#f5f5f5', color: '#1a1a2e',
-                  '&:hover': { bgcolor: '#eaeaea', borderColor: 'rgba(0,0,0,0.2)' },
+                  border: `1px solid ${c.border}`, bgcolor: c.chromeBg, color: c.textPrimary,
+                  '&:hover': { bgcolor: c.chromeBgHover, borderColor: c.borderHover },
                   '&:disabled': { opacity: 0.4 },
                 }}
               >
@@ -651,13 +667,13 @@ function ColorPicker() {
                 width: 34,
                 height: 34,
                 borderRadius: '8px',
-                border: '1px solid rgba(0,0,0,0.12)',
-                bgcolor: '#f5f5f5',
-                color: '#1a1a2e',
+                border: `1px solid ${c.border}`,
+                bgcolor: c.chromeBg,
+                color: c.textPrimary,
                 transition: 'all 0.15s ease',
                 '&:hover': {
-                  bgcolor: '#eaeaea',
-                  borderColor: 'rgba(0,0,0,0.2)',
+                  bgcolor: c.chromeBgHover,
+                  borderColor: c.borderHover,
                 },
               }}
             >
@@ -717,13 +733,13 @@ function ColorPicker() {
                   Rename
                 </Button>
               </Tooltip>
-              <Box sx={{ width: '1px', height: 24, bgcolor: 'rgba(0,0,0,0.1)' }} />
+              <Box sx={{ width: '1px', height: 24, bgcolor: c.divider }} />
             </>
           )}
 
           {/* Contrast Mode Toggle */}
           <Tooltip title='Contrast text 戦略 (light mode のみ適用 / dark mode は常に A11y 自動選択)' arrow>
-            <Box sx={{ display: 'flex', bgcolor: '#f5f5f5', borderRadius: '8px', border: '1px solid rgba(0,0,0,0.1)', p: '2px' }}>
+            <Box sx={{ display: 'flex', bgcolor: c.chromeBg, borderRadius: '8px', border: `1px solid ${c.divider}`, p: '2px' }}>
               {(['auto', 'white', 'black'] as ContrastMode[]).map(m => (
                 <Box
                   key={m}
@@ -737,9 +753,9 @@ function ColorPicker() {
                     fontWeight: 600,
                     borderRadius: '6px',
                     cursor: 'pointer',
-                    bgcolor: contrastMode === m ? '#fff' : 'transparent',
-                    color: contrastMode === m ? '#1a1a2e' : 'rgba(0,0,0,0.5)',
-                    boxShadow: contrastMode === m ? '0 1px 2px rgba(0,0,0,0.06)' : 'none',
+                    bgcolor: contrastMode === m ? c.chromeBgActive : 'transparent',
+                    color: contrastMode === m ? c.textPrimary : c.textMuted,
+                    boxShadow: contrastMode === m ? `0 1px 2px ${c.shadow}` : 'none',
                     textTransform: 'uppercase',
                     letterSpacing: '0.03em',
                     transition: 'all 0.15s ease',
@@ -753,7 +769,7 @@ function ColorPicker() {
 
           {/* A11y Threshold Toggle */}
           <Tooltip title='A11y 許容しきい値（通常テキスト 14-16px 想定）: None (無効) / A (≥3:1, 大きい文字向け) / AA (≥4.5:1, WCAG 標準) / AAA (≥7:1, 強化)' arrow>
-            <Box sx={{ display: 'flex', bgcolor: '#f5f5f5', borderRadius: '8px', border: '1px solid rgba(0,0,0,0.1)', p: '2px' }}>
+            <Box sx={{ display: 'flex', bgcolor: c.chromeBg, borderRadius: '8px', border: `1px solid ${c.divider}`, p: '2px' }}>
               {(['none', 'A', 'AA', 'AAA'] as A11yThreshold[]).map(t => (
                 <Box
                   key={t}
@@ -767,9 +783,9 @@ function ColorPicker() {
                     fontWeight: 600,
                     borderRadius: '6px',
                     cursor: 'pointer',
-                    bgcolor: a11yThreshold === t ? '#fff' : 'transparent',
-                    color: a11yThreshold === t ? '#1a1a2e' : 'rgba(0,0,0,0.5)',
-                    boxShadow: a11yThreshold === t ? '0 1px 2px rgba(0,0,0,0.06)' : 'none',
+                    bgcolor: a11yThreshold === t ? c.chromeBgActive : 'transparent',
+                    color: a11yThreshold === t ? c.textPrimary : c.textMuted,
+                    boxShadow: a11yThreshold === t ? `0 1px 2px ${c.shadow}` : 'none',
                     letterSpacing: '0.03em',
                     transition: 'all 0.15s ease',
                   }}
@@ -781,7 +797,7 @@ function ColorPicker() {
           </Tooltip>
 
           {/* Divider */}
-          <Box sx={{ width: '1px', height: 24, bgcolor: 'rgba(0,0,0,0.1)' }} />
+          <Box sx={{ width: '1px', height: 24, bgcolor: c.divider }} />
 
           {/* Navigation */}
           <Button
@@ -798,10 +814,10 @@ function ColorPicker() {
               size='small'
               sx={{
                 width: 34, height: 34, borderRadius: '8px',
-                border: '1px solid rgba(0,0,0,0.12)',
-                bgcolor: greyscale ? '#1a1a2e' : '#f5f5f5',
-                color: greyscale ? '#fff' : '#1a1a2e',
-                '&:hover': { bgcolor: greyscale ? '#2c2c44' : '#eaeaea' },
+                border: `1px solid ${c.border}`,
+                bgcolor: greyscale ? c.textPrimary : c.chromeBg,
+                color: greyscale ? c.pageBg : c.textPrimary,
+                '&:hover': { bgcolor: greyscale ? c.textPrimary : c.chromeBgHover, opacity: greyscale ? 0.85 : 1 },
               }}
             >
               <svg width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'>
@@ -812,7 +828,7 @@ function ColorPicker() {
           </Tooltip>
 
           {/* Divider */}
-          <Box sx={{ width: '1px', height: 24, bgcolor: 'rgba(0,0,0,0.1)' }} />
+          <Box sx={{ width: '1px', height: 24, bgcolor: c.divider }} />
 
           {/* Figma */}
           {figmaConnected ? (
@@ -837,7 +853,7 @@ function ColorPicker() {
           )}
 
           {/* Divider */}
-          <Box sx={{ width: '1px', height: 24, bgcolor: 'rgba(0,0,0,0.1)' }} />
+          <Box sx={{ width: '1px', height: 24, bgcolor: c.divider }} />
 
           {/* Export / Import / Help (右端グループ) */}
           <Tooltip title='Export (JSON/DTCG/CSS/SCSS/MUI/Tailwind/MCP)' arrow>
@@ -885,8 +901,11 @@ function ColorPicker() {
             Help
           </Button>
 
+          {/* App color scheme toggle (Light / Dark / System) */}
+          <ColorSchemeToggle />
+
           {/* Divider */}
-          <Box sx={{ width: '1px', height: 24, bgcolor: 'rgba(0,0,0,0.1)' }} />
+          <Box sx={{ width: '1px', height: 24, bgcolor: c.divider }} />
 
           {/* Cloud / Auth (Firebase 未設定時は非表示) */}
           {!firebaseReady ? null : user ? (
@@ -954,15 +973,15 @@ function ColorPicker() {
           scrollbarWidth: 'thin',
           scrollBehavior: 'smooth',
           '&::-webkit-scrollbar': { height: 8 },
-          '&::-webkit-scrollbar-track': { bgcolor: 'rgba(0,0,0,0.03)', borderRadius: 4 },
+          '&::-webkit-scrollbar-track': { bgcolor: c.divider, borderRadius: 4 },
           '&::-webkit-scrollbar-thumb': {
-            bgcolor: 'rgba(0,0,0,0.15)',
+            bgcolor: c.border,
             borderRadius: 4,
-            '&:hover': { bgcolor: 'rgba(0,0,0,0.25)' },
+            '&:hover': { bgcolor: c.borderHover },
           },
         }}
       >
-        {color.map((c, index) => (
+        {color.map((hex, index) => (
           <Box
             key={index}
             sx={{
@@ -982,8 +1001,8 @@ function ColorPicker() {
                 mb: 1,
                 '& .MuiOutlinedInput-root': {
                   borderRadius: '8px',
-                  '& fieldset': { borderColor: 'rgba(0,0,0,0.08)' },
-                  '&:hover fieldset': { borderColor: 'rgba(0,0,0,0.15)' },
+                  '& fieldset': { borderColor: c.divider },
+                  '&:hover fieldset': { borderColor: c.border },
                   '&.Mui-focused fieldset': {
                     borderColor: '#3f50b5',
                     borderWidth: '2px',
@@ -997,7 +1016,7 @@ function ColorPicker() {
               }}
             />
             <ColorInputField
-              color={c}
+              color={hex}
               onChange={newColor => handleColorChange(index, newColor)}
             />
             {palette && palette[index] && (
@@ -1018,13 +1037,13 @@ function ColorPicker() {
 
       {/* ===== Theme Tokens (grey + utility) ===== */}
       {themeTokens && (
-        <Box sx={{ mt: 4, pt: 3, borderTop: '1px solid rgba(0,0,0,0.06)' }}>
+        <Box sx={{ mt: 4, pt: 3, borderTop: `1px solid ${c.divider}` }}>
           <Typography
             component='h2'
             sx={{
               fontSize: '0.85rem',
               fontWeight: 700,
-              color: 'rgba(0,0,0,0.5)',
+              color: c.textMuted,
               textTransform: 'uppercase',
               letterSpacing: '0.05em',
               mb: 2,
@@ -1036,7 +1055,7 @@ function ColorPicker() {
               sx={{
                 fontSize: '0.75rem',
                 fontWeight: 400,
-                color: 'rgba(0,0,0,0.3)',
+                color: c.textSubtle,
                 ml: 1,
               }}
             >
@@ -1056,11 +1075,11 @@ function ColorPicker() {
               scrollbarWidth: 'thin',
               scrollBehavior: 'smooth',
               '&::-webkit-scrollbar': { height: 8 },
-              '&::-webkit-scrollbar-track': { bgcolor: 'rgba(0,0,0,0.03)', borderRadius: 4 },
+              '&::-webkit-scrollbar-track': { bgcolor: c.divider, borderRadius: 4 },
               '&::-webkit-scrollbar-thumb': {
-                bgcolor: 'rgba(0,0,0,0.15)',
+                bgcolor: c.border,
                 borderRadius: 4,
-                '&:hover': { bgcolor: 'rgba(0,0,0,0.25)' },
+                '&:hover': { bgcolor: c.borderHover },
               },
             }}
           >
@@ -1213,7 +1232,7 @@ function ColorPicker() {
         onConfirm={handleConfirm}
         onCancel={handleCancel}
       />
-    </>
+    </Box>
   );
 }
 

--- a/src/components/common/AppShell.tsx
+++ b/src/components/common/AppShell.tsx
@@ -1,0 +1,20 @@
+import React, { useMemo } from 'react';
+import { ThemeProvider } from '@emotion/react';
+import CssBaseline from '@mui/material/CssBaseline';
+import { createAppTheme } from '@/lib/theme';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+// _app.tsx の ThemeProvider を動的にするためのラッパー。
+// useColorScheme は hook なので function component 内でしか呼べないため、
+// _app.tsx 本体から切り出している。
+export function AppShell({ children }: { children: React.ReactNode }) {
+  const { resolved } = useColorScheme();
+  const theme = useMemo(() => createAppTheme(resolved), [resolved]);
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </ThemeProvider>
+  );
+}

--- a/src/components/common/ColorSchemeToggle.tsx
+++ b/src/components/common/ColorSchemeToggle.tsx
@@ -1,0 +1,92 @@
+import React, { memo } from 'react';
+import { Box, Tooltip } from '@mui/material';
+import { useColorScheme, ColorScheme } from '@/hooks/useColorScheme';
+import { useAppColors } from '@/hooks/useAppColors';
+
+// 太陽 / 月 / モニター（system）の 3-state トグル。ヘッダーに配置して
+// Generator 全体の外観モードを切り替える。user palette の light/dark
+// カードとは独立軸。
+export const ColorSchemeToggle = memo(() => {
+  const { scheme, setScheme } = useColorScheme();
+  const c = useAppColors();
+
+  const options: { value: ColorScheme; label: string; icon: React.ReactNode }[] = [
+    {
+      value: 'light',
+      label: 'Light',
+      icon: (
+        <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'>
+          <circle cx='12' cy='12' r='4' />
+          <path d='M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41' />
+        </svg>
+      ),
+    },
+    {
+      value: 'dark',
+      label: 'Dark',
+      icon: (
+        <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'>
+          <path d='M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z' />
+        </svg>
+      ),
+    },
+    {
+      value: 'system',
+      label: 'System (OS)',
+      icon: (
+        <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'>
+          <rect x='3' y='4' width='18' height='12' rx='1.5' />
+          <path d='M8 20h8M12 16v4' />
+        </svg>
+      ),
+    },
+  ];
+
+  return (
+    <Tooltip arrow title={`App theme: ${scheme}（Light / Dark / System OS 追従）`}>
+      <Box
+        sx={{
+          display: 'flex',
+          bgcolor: c.chromeBg,
+          borderRadius: '8px',
+          border: `1px solid ${c.border}`,
+          p: '2px',
+        }}
+      >
+        {options.map(opt => {
+          const active = scheme === opt.value;
+          return (
+            <Box
+              key={opt.value}
+              component='button'
+              type='button'
+              onClick={() => setScheme(opt.value)}
+              aria-label={`Set app theme to ${opt.label}`}
+              aria-pressed={active}
+              sx={{
+                border: 0,
+                px: 1,
+                py: 0.5,
+                display: 'inline-flex',
+                alignItems: 'center',
+                fontSize: '0.7rem',
+                fontWeight: 600,
+                borderRadius: '6px',
+                cursor: 'pointer',
+                bgcolor: active ? c.chromeBgActive : 'transparent',
+                color: active ? c.textPrimary : c.textMuted,
+                boxShadow: active ? `0 1px 2px ${c.shadow}` : 'none',
+                letterSpacing: '0.03em',
+                transition: 'all 0.15s ease',
+                '&:hover': { bgcolor: active ? c.chromeBgActive : c.chromeBgHover },
+              }}
+            >
+              {opt.icon}
+            </Box>
+          );
+        })}
+      </Box>
+    </Tooltip>
+  );
+});
+ColorSchemeToggle.displayName = 'ColorSchemeToggle';

--- a/src/components/example/ExampleDialog.tsx
+++ b/src/components/example/ExampleDialog.tsx
@@ -47,15 +47,20 @@ export const ExampleDialog = memo<ExampleDialogProps>(
             justifyContent: 'space-between',
             py: 1.5,
             px: 3,
-            borderBottom: '1px solid rgba(0,0,0,0.08)',
-            bgcolor: '#fff',
+            borderBottom: 1,
+            borderColor: 'divider',
+            // ExampleDialog の DialogTitle は外側の `_app.tsx` theme（light
+            // または dark）を反映させるため `background.paper` 参照に。中身
+            // (DialogContent 内) は入れ子 ThemeProvider で buildMuiTheme が
+            // 支配するが、title は外側 chrome なので ここでは palette ref のまま
+            bgcolor: 'background.paper',
           }}
         >
           <Box>
             <Typography sx={{ fontSize: '1rem', fontWeight: 700 }}>
               Theme Preview
             </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'rgba(0,0,0,0.55)', mt: 0.25 }}>
+            <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary', mt: 0.25 }}>
               {paletteData.names?.[0] ?? 'primary'} — {paletteData.colors[0] ?? '-'}
             </Typography>
           </Box>

--- a/src/components/export/ExportHubDialog.tsx
+++ b/src/components/export/ExportHubDialog.tsx
@@ -83,7 +83,7 @@ export const ExportHubDialog = memo<ExportHubDialogProps>(
             justifyContent: 'space-between',
             py: 2,
             px: 3,
-            borderBottom: '1px solid rgba(0,0,0,0.08)',
+            borderBottom: 1, borderColor: 'divider',
           }}
         >
           <Typography sx={{ fontSize: '1rem', fontWeight: 700 }}>
@@ -103,7 +103,7 @@ export const ExportHubDialog = memo<ExportHubDialogProps>(
           variant='scrollable'
           scrollButtons='auto'
           sx={{
-            borderBottom: '1px solid rgba(0,0,0,0.08)',
+            borderBottom: 1, borderColor: 'divider',
             '& .MuiTab-root': {
               textTransform: 'none',
               fontSize: '0.8rem',
@@ -125,8 +125,9 @@ export const ExportHubDialog = memo<ExportHubDialogProps>(
               justifyContent: 'space-between',
               px: 3,
               py: 1.5,
-              borderBottom: '1px solid rgba(0,0,0,0.05)',
-              bgcolor: '#fafafa',
+              borderBottom: 1,
+              borderColor: 'divider',
+              bgcolor: 'background.default',
             }}
           >
             <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>

--- a/src/components/harmony/HarmonyDialog.tsx
+++ b/src/components/harmony/HarmonyDialog.tsx
@@ -65,7 +65,8 @@ export const HarmonyDialog = memo<HarmonyDialogProps>(
             justifyContent: 'space-between',
             py: 2,
             px: 3,
-            borderBottom: '1px solid rgba(0,0,0,0.08)',
+            borderBottom: 1,
+            borderColor: 'divider',
           }}
         >
           <Typography sx={{ fontSize: '1rem', fontWeight: 700 }}>

--- a/src/components/help/HelpDialog.tsx
+++ b/src/components/help/HelpDialog.tsx
@@ -30,7 +30,8 @@ export const HelpDialog = memo<HelpDialogProps>(({ open, onClose }) => {
           justifyContent: 'space-between',
           py: 2,
           px: 3,
-          borderBottom: '1px solid rgba(0,0,0,0.08)',
+          borderBottom: 1,
+          borderColor: 'divider',
         }}
       >
         <Box>

--- a/src/hooks/useAppColors.ts
+++ b/src/hooks/useAppColors.ts
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+import { useColorScheme } from './useColorScheme';
+
+// Generator chrome 用の意味的な色マップ。ColorPicker.tsx などで散在していた
+// ハードコード色 (#1a1a2e / #f5f5f5 / rgba(0,0,0,0.xx) など) を集約し、
+// useColorScheme の resolved に応じて light/dark の値を返す。
+//
+// 注意: user palette (PaletteCard 内の色) はこのフックを使わず、生成された
+// 5 シェードをそのまま表示する（ユーザー設計対象の色に手を入れない原則）。
+export type AppColors = {
+  pageBg: string;
+  chromeBg: string;        // header/toolbar の button や toggle container 背景
+  chromeBgHover: string;
+  chromeBgActive: string;  // toggle 選択状態の背景
+  textPrimary: string;
+  textMuted: string;       // 通常ラベル (secondary)
+  textSubtle: string;      // captions / helper
+  border: string;          // 通常のボーダー
+  borderHover: string;
+  divider: string;         // 薄い区切り
+  shadow: string;          // box-shadow の rgba 部
+};
+
+const LIGHT: AppColors = {
+  pageBg: '#ffffff',
+  chromeBg: '#f5f5f5',
+  chromeBgHover: '#eaeaea',
+  chromeBgActive: '#ffffff',
+  textPrimary: '#1a1a2e',
+  textMuted: 'rgba(0,0,0,0.55)',
+  textSubtle: 'rgba(0,0,0,0.38)',
+  border: 'rgba(0,0,0,0.12)',
+  borderHover: 'rgba(0,0,0,0.22)',
+  divider: 'rgba(0,0,0,0.1)',
+  shadow: 'rgba(0,0,0,0.06)',
+};
+
+const DARK: AppColors = {
+  pageBg: '#18181b',
+  chromeBg: '#27272a',
+  chromeBgHover: '#3f3f46',
+  chromeBgActive: '#52525b',
+  textPrimary: '#e4e4e7',
+  textMuted: 'rgba(255,255,255,0.7)',
+  textSubtle: 'rgba(255,255,255,0.5)',
+  border: 'rgba(255,255,255,0.14)',
+  borderHover: 'rgba(255,255,255,0.28)',
+  divider: 'rgba(255,255,255,0.1)',
+  shadow: 'rgba(0,0,0,0.4)',
+};
+
+export function useAppColors(): AppColors {
+  const { resolved } = useColorScheme();
+  return useMemo(() => (resolved === 'dark' ? DARK : LIGHT), [resolved]);
+}
+
+// hook が使えない文脈 (SSR 等) 用の getter
+export function getAppColors(resolved: 'light' | 'dark'): AppColors {
+  return resolved === 'dark' ? DARK : LIGHT;
+}

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useState } from 'react';
+
+// App 全体のライト/ダーク切替。user palette (PaletteCard の light/dark カード)
+// とは独立軸で、Generator chrome（ヘッダー、ツールバー、Dialog、Page 背景）を
+// 切り替える。localStorage に永続化、user が明示的に 'system' を選んだとき
+// だけ OS の prefers-color-scheme に追従する。
+//
+// 初回訪問は **必ず 'light' スタート**。OS が dark でも勝手に切り替えない
+// （初期 'system' にすると hydration 直後に OS 設定で dark になって体験が悪い）。
+
+export type ColorScheme = 'light' | 'dark' | 'system';
+type Resolved = 'light' | 'dark';
+
+const STORAGE_KEY = 'palettePallyColorScheme';
+
+function resolveSystem(): Resolved {
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyAttr(resolved: Resolved): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.dataset.colorScheme = resolved;
+  // フォームコントロール / スクロールバーを OS のダーク色に追従
+  document.documentElement.style.colorScheme = resolved;
+}
+
+export function useColorScheme(): {
+  scheme: ColorScheme;
+  resolved: Resolved;
+  setScheme: (s: ColorScheme) => void;
+  toggle: () => void;
+} {
+  // SSR / hydration mismatch を避けるため初期値は常に 'light'。
+  // mount 後に localStorage / OS を解決する。
+  const [scheme, setSchemeState] = useState<ColorScheme>('light');
+  const [resolved, setResolved] = useState<Resolved>('light');
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY) as ColorScheme | null;
+      const initial = saved && ['light', 'dark', 'system'].includes(saved) ? saved : 'light';
+      setSchemeState(initial);
+      const r = initial === 'system' ? resolveSystem() : initial;
+      setResolved(r);
+      applyAttr(r);
+    } catch { /* localStorage 不可環境は light 固定 */ }
+  }, []);
+
+  // 'system' 選択中は OS 設定の変化に追従
+  useEffect(() => {
+    if (scheme !== 'system' || typeof window === 'undefined') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const listener = () => {
+      const r = mq.matches ? 'dark' : 'light';
+      setResolved(r);
+      applyAttr(r);
+    };
+    mq.addEventListener?.('change', listener);
+    return () => mq.removeEventListener?.('change', listener);
+  }, [scheme]);
+
+  const setScheme = useCallback((s: ColorScheme) => {
+    setSchemeState(s);
+    const r = s === 'system' ? resolveSystem() : s;
+    setResolved(r);
+    applyAttr(r);
+    try {
+      localStorage.setItem(STORAGE_KEY, s);
+    } catch { /* ignore */ }
+  }, []);
+
+  const toggle = useCallback(() => {
+    // light → dark → system → light ... の 3-state サイクル
+    setScheme(scheme === 'light' ? 'dark' : scheme === 'dark' ? 'system' : 'light');
+  }, [scheme, setScheme]);
+
+  return { scheme, resolved, setScheme, toggle };
+}

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -50,7 +50,11 @@ export function useColorScheme(): {
   // 'system' 選択中は OS 設定の変化に追従
   useEffect(() => {
     if (scheme !== 'system' || typeof window === 'undefined') return;
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    // jsdom など matchMedia 未実装環境でも落とさない
+    const mq = typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-color-scheme: dark)')
+      : null;
+    if (!mq) return;
     const listener = () => {
       const r = mq.matches ? 'dark' : 'light';
       setResolved(r);

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { createTheme } from '@mui/material/styles';
+import { createTheme, Theme, ThemeOptions } from '@mui/material/styles';
 import { CSSProperties } from 'react';
 import { TypographyStyleOptions } from '@mui/material/styles/createTypography';
 import { colorData } from '@/lib/colorToken';
@@ -451,3 +451,76 @@ export const theme = createTheme({
   },
   */
 });
+
+// ── App-level dark theme ──
+// 既存の light theme を base に palette / typography を dark 用に上書き。
+// useColorScheme の resolved === 'dark' のとき AppShell が createAppTheme('dark')
+// で差し替える。user palette (PaletteCard) には影響しない（こちらは自分の
+// 色を持つ別レイヤー）。
+const darkText = {
+  primary: '#e4e4e7',
+  secondary: '#a1a1aa',
+  disabled: '#9ca3af',
+};
+const darkBg = {
+  default: '#18181b',
+  paper: '#27272a',
+};
+
+// dark 用の allVariants。既存 light の allVariants と fontFamily / weight /
+// line-height は共通だが、color だけ明示的に dark 値を設定。
+// （createTheme 後の theme.typography から allVariants を再スプレッドすると
+//   型が壊れるため、両 theme 作成時の input 側で揃える）
+const sharedAllVariants = {
+  fontFamily: 'Jost, Inter, Noto Sans JP, Helvetica, Arial, sans-serif',
+  lineHeight: lineHeight.medium,
+  fontWeight: fontWeight.normal,
+  textTransform: 'inherit' as const,
+  WebkitFontSmoothing: 'antialiased' as const,
+  MozOsxFontSmoothing: 'antialiased' as const,
+  fontSize: pxToRem(baseFontSize),
+};
+
+export const darkTheme = createTheme({
+  ...(theme as unknown as ThemeOptions),
+  palette: {
+    ...(theme.palette as unknown as ThemeOptions['palette']),
+    mode: 'dark',
+    text: darkText,
+    background: darkBg,
+    divider: 'rgba(255,255,255,0.12)',
+    // カスタム surface / icon を dark 用に再指定（declare module で必須のため）
+    surfaceBackground: '#1e1e22',
+    surfaceBackgroundDark: '#09090b',
+    surfaceBackgroundDisabled: '#333338',
+    iconWhite: colorData.icon.white,
+    iconLight: '#a1a1aa',
+    iconDark: '#e4e4e7',
+    iconAction: colorData.icon.action,
+    iconDisabled: '#52525b',
+  },
+  typography: {
+    ...(theme.typography as unknown as ThemeOptions['typography']),
+    // 親 theme の allVariants.color が固定で入れ子 ThemeProvider を貫通する
+    // ため、dark theme では allVariants.color を明示的に dark 値に。
+    allVariants: {
+      ...sharedAllVariants,
+      color: darkText.primary,
+    },
+  },
+  components: {
+    ...theme.components,
+    MuiCssBaseline: {
+      styleOverrides: {
+        body: {
+          backgroundColor: darkBg.default,
+          color: darkText.primary,
+        },
+      },
+    },
+  },
+});
+
+export function createAppTheme(mode: 'light' | 'dark'): Theme {
+  return mode === 'dark' ? darkTheme : theme;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -17,7 +17,21 @@ body {
   padding: 1vh 3vw;
   max-width: 1440px;
   margin: auto;
-  color: #345;
+  color: #1a1a2e;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+/* App-level color scheme: useColorScheme が html[data-color-scheme] を付与する。
+   MUI CssBaseline も同じ値を当てるが、hydration 直前のちらつき防止に CSS 側で
+   先行して body 背景/文字色を切り替える。 */
+html[data-color-scheme='dark'] body {
+  background-color: #18181b;
+  color: #e4e4e7;
+}
+
+html[data-color-scheme='light'] body {
+  background-color: #ffffff;
+  color: #1a1a2e;
 }
 
 a {


### PR DESCRIPTION
Closes #9

## Summary
App 全体のライト/ダーク切替を実装。`useColorScheme` フックと動的 `ThemeProvider` を核に、Generator chrome（ヘッダー / ツールバー / Dialog / ページ背景）を切り替え、user palette (PaletteCard の light/dark カード) は独立軸で保持する。

## 構成 (4 commits = 4 Phase)

### Phase 1 — 基盤
- `src/hooks/useColorScheme.ts`: `'light' | 'dark' | 'system'` 3-state、localStorage 永続化、OS prefers-color-scheme 追従（system 選択時のみ）。初期は必ず `'light'`（hydration mismatch 防止）
- `src/hooks/useAppColors.ts`: Generator chrome 用の意味的トークン（`chromeBg` / `textPrimary` / `border` / `divider` 等）
- `src/lib/theme.ts` に `darkTheme` と `createAppTheme(mode)` 追加。親の `typography.allVariants.color` が入れ子 ThemeProvider を貫通するのを防ぐため dark 版 `allVariants.color` を明示
- `src/components/common/AppShell.tsx`: `_app.tsx` の `ThemeProvider` を動的に差し替えるラッパー
- `globals.css`: `html[data-color-scheme]` で body 背景/文字色を先行切替（ちらつき防止）

### Phase 2 — ColorPicker.tsx + Toggle
- `ColorSchemeToggle` コンポーネントをヘッダー右端に配置（太陽 / 月 / モニター の 3-state）
- ColorPicker.tsx 内の `'#1a1a2e'` / `'#f5f5f5'` / `'rgba(0,0,0,0.xx)'` 系のハードコード色を `useAppColors` の意味トークンに全置換
- ロゴ SVG の固定色を `currentColor` 化して親の `color` から制御
- wrapper Box に `bgcolor: c.pageBg` / `color: c.textPrimary` / `minHeight: 100vh`
- `color.map((c, idx))` の仮引数 `c` が useAppColors の `c` と shadow するのを `hex` に rename

### Phase 3 — Dialog chrome
ExampleDialog / HelpDialog / HarmonyDialog / ExportHubDialog / ColorInputField の DialogTitle・Toolbar にあるハードコードを MUI theme ref (`'background.paper'` / `'text.primary'` / `'divider'` 等) に置換。dark theme (`palette.background.paper = '#27272a'`) が自動適用される。

**PaletteGrid.tsx は意図的にスコープ外**: user palette の light/dark カードは独立軸で保持する（issue 本文の受け入れ基準「Does not interfere with the user palette display」準拠）。

### Phase 4 — テスト
- `useColorScheme.test.tsx` (5 ケース): 初期 light、localStorage 復元、toggle サイクル、不正値フォールバック
- `createAppTheme.test.ts` (7 ケース): light/dark 切替、dark text の WCAG AA/AA-Large 検証、`typography.allVariants.color` 汚染遮断の検証

## Test result
- [x] `tsc --noEmit` 緑
- [x] 全 24 suites / 270 tests 緑（新規 12 ケース）
- [ ] Lighthouse accessibility score = 100（CI 上の `.github/workflows/lighthouse.yml` で自動計測）

## Acceptance criteria
- [x] Dark mode toggle shows Generator UI in dark with all text readable（ColorPicker.tsx 置換 + `text.primary` 4.5:1 保証）
- [x] WCAG AA contrast maintained（テストで text.primary/secondary 4.5:1、disabled 3:1 を検証）
- [x] Does not interfere with the user palette display（PaletteGrid はスコープ外）